### PR TITLE
Fix/liquid background resize observer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,22 +48,22 @@ local-preview: website-build
 	wait
 	@echo "Both processes have finished."
 
-## local-docker-lint, fetching non-local target and linting all project's images
-.PHONY: local-docker-lint
-local-docker-lint: 
-	make docker-lint DOCKER_IMAGE=ioaiaaii 
+## local-image-lint, fetching non-local target and linting all project's images
+.PHONY: local-image-lint
+local-image-lint:
+	make image-lint DOCKER_IMAGE=ioaiaaii
 
-## local-docker-build, fetching non-local target and building all project's images
-.PHONY: local-docker-build
-local-docker-build: 
-	make docker-image DOCKER_IMAGE=ioaiaaii 
+## local-image-build, fetching non-local target and building all project's images
+.PHONY: local-image-build
+local-image-build:
+	make docker-image DOCKER_IMAGE=ioaiaaii
 
 ## local-docker-push, fetching non-local target and building all project's images
 .PHONY: local-docker-push
-local-docker-push: 
+local-docker-push:
 	make docker-push DOCKER_IMAGE_REPO="europe-west3-docker.pkg.dev/micro-infra/micro-repo" DOCKER_IMAGE=ioaiaaii
 
-## local-docker-run, fetching non-local target docker-run and run all images in the backround
-.PHONY: local-docker-run
-local-docker-run: 
+## local-image-run, fetching non-local target docker-run and run all images in the backround
+.PHONY: local-image-run
+local-image-run:
 	make docker-run DOCKER_IMAGE=ioaiaaii

--- a/deploy/helm/ioaiaaii/Chart.yaml
+++ b/deploy/helm/ioaiaaii/Chart.yaml
@@ -3,7 +3,7 @@ annotations:
   licenses: Apache-2.0
 type: application
 apiVersion: v2
-appVersion: v2.0.0
+appVersion: v2.0.1
 dependencies:
   - name: common
     repository: oci://registry-1.docker.io/bitnamicharts
@@ -19,4 +19,4 @@ name: ioaiaaii
 sources:
   - https://github.com/ioaiaaii/ioaiaaii.net/tree/master/deploy
   - https://github.com/ioaiaaii/ioaiaaii.net/tree/master/build/package
-version: 1.2.1
+version: 1.2.2

--- a/web/src/components/Contact.vue
+++ b/web/src/components/Contact.vue
@@ -4,8 +4,8 @@
       <h1 class="sr-only">Contact Information</h1>
 
       <!-- Loading State -->
-      <div v-if="isLoading" class="text-center py-8">
-        <p class="resume-text opacity-50">Loading contact info...</p>
+      <div v-if="isLoading" class="flex justify-center py-8">
+        <div class="w-6 h-6 border-2 border-gray-300 border-t-gray-500 rounded-full animate-spin" />
       </div>
 
       <!-- Error State -->

--- a/web/src/components/Info.vue
+++ b/web/src/components/Info.vue
@@ -4,8 +4,8 @@
     <div class="w-full px-4 sm:px-6 md:px-8 lg:px-0 lg:w-2/3 xl:w-1/2 py-8 sm:py-10 md:py-12 pb-20">
 
     <!-- Loading State -->
-    <div v-if="isLoading" class="text-center py-4">
-      <p class="resume-text opacity-50">Loading profile...</p>
+    <div v-if="isLoading" class="flex justify-center py-4">
+      <div class="w-6 h-6 border-2 border-gray-300 border-t-gray-500 rounded-full animate-spin" />
     </div>
 
     <!-- Error State -->

--- a/web/src/components/Live.vue
+++ b/web/src/components/Live.vue
@@ -4,8 +4,8 @@
       <h1 class="sr-only">Live Performances</h1>
 
       <!-- Loading State -->
-      <div v-if="isLoading" class="text-center py-8">
-        <p class="live-text opacity-50">Loading performances...</p>
+      <div v-if="isLoading" class="flex justify-center py-8">
+        <div class="w-6 h-6 border-2 border-gray-300 border-t-gray-500 rounded-full animate-spin" />
       </div>
 
       <!-- Error State -->

--- a/web/src/components/insprira/LiquidBackground.vue
+++ b/web/src/components/insprira/LiquidBackground.vue
@@ -1,14 +1,16 @@
 <template>
   <div
     ref="ctnDom"
-    :class="cn('block size-full', props?.class)"
-  ></div>
+    class="block size-full"
+    :class="[props?.class]"
+  />
 </template>
 
 <script lang="ts" setup>
-import { onMounted, onUnmounted, ref, type HTMLAttributes } from "vue";
-import { Renderer, Program, Mesh, Color, Triangle, type OGLRenderingContext } from "ogl";
-import { cn } from "@/lib/utils";
+import type { HTMLAttributes } from "vue";
+import type { OGLRenderingContext } from "ogl";
+import { Color, Mesh, Program, Renderer, Triangle } from "ogl";
+import { onMounted, onUnmounted, ref } from "vue";
 
 const props = defineProps<{ class?: HTMLAttributes["class"] }>();
 
@@ -94,8 +96,14 @@ function update(t: number) {
   }
 }
 
-onMounted(() => {
+function initWebGL() {
   if (!ctnDom.value) return;
+
+  // Defer until the container has non-zero dimensions (CSS may not have applied yet)
+  if (ctnDom.value.offsetWidth === 0 || ctnDom.value.offsetHeight === 0) {
+    requestAnimationFrame(initWebGL);
+    return;
+  }
 
   renderer = new Renderer();
   gl = renderer.gl;
@@ -122,6 +130,11 @@ onMounted(() => {
   animateId = requestAnimationFrame(update);
 
   ctnDom.value.appendChild(gl.canvas);
+  console.log(`[LiquidBackground] WebGL initialized (${gl.canvas.width}x${gl.canvas.height})`);
+}
+
+onMounted(() => {
+  initWebGL();
 });
 
 onUnmounted(() => {

--- a/website/data/releases.json
+++ b/website/data/releases.json
@@ -3,7 +3,7 @@
     {
       "title": "NSA Trusted Networks",
       "artist": "Ioannis Savvaidis",
-      "releaseDate": "2018-12-15",
+      "releaseDate": "2016-12-30",
       "label": "Lower Parts",
       "discogs_link": "https://www.discogs.com/release/9283679-Ioannis-Savvaidis-NSA-Trusted-Networks",
       "bandcamp_link": "https://lowerparts.bandcamp.com/album/nsa-trusted-networks-2",
@@ -12,7 +12,7 @@
     {
       "title": "Diataxis",
       "artist": "Ioannis Savvaidis",
-      "releaseDate": "2019-05-20",
+      "releaseDate": "2019-05-18",
       "label": "JUNE Records",
       "discogs_link": "https://www.discogs.com/release/13775276-Ioannis-Savvaidis-Diataxis-",
       "bandcamp_link": "https://ioannissavvaidis.bandcamp.com/album/diataxis",
@@ -21,7 +21,7 @@
     {
       "title": "DEC/PDC",
       "artist": "Ioannis Savvaidis",
-      "releaseDate": "2020-01-10",
+      "releaseDate": "2019-11-19",
       "label": "JUNE Records",
       "discogs_link": "https://www.discogs.com/release/14420107-Ioannis-Savvaidis-DECPDC",
       "bandcamp_link": "https://ioannissavvaidis.bandcamp.com/album/dec-pdc",


### PR DESCRIPTION
### Context

After v2, in cold cached runtime, there was a bug in timmings of js and css, CSS did not load the layout and js background was not loading.
<img width="1444" height="442" alt="Screenshot 2026-02-24 at 1 47 21 PM" src="https://github.com/user-attachments/assets/86ff9aed-e304-400e-95ae-51648bfc285f" />

### Suggested Solution

Force init the webGL stuff.